### PR TITLE
Error con Keys.find() ??

### DIFF
--- a/api_server/services/index.js
+++ b/api_server/services/index.js
@@ -12,15 +12,15 @@ const rsa = require('../module/rsa');
 
 
 function createKeys(req) {
-	Keys.find({ keytype: req } , function (err, key){
-			if(err) {
-				console.log(`ERROR: Petitions doesn't do: ${err}`);
-        return;
-			}
-			if(key){
-        console.log(`Keys existed for ${req} `);
-        return;
-      }
+	Keys.findOne({ keytype: req } , function (err, key){
+        if(err) {
+            console.log(`ERROR: Petitions doesn't do: ${err}`);
+            return;
+        }
+        if(key){
+            console.log(`Keys existed for ${req} `);
+            return;
+        }
       else{
         console.log(`ERROR: Doesn't exist the keys for ${req} `);
 				var bitslength = config.bitslength;


### PR DESCRIPTION
Como esto alomejor os afecta lo pongo por aqui.

Si en lugar de Kyes.findOne() se utiliza Keys.find(), cuando hace el if(key) siempre devuelve true, por lo que siempre interpreta que ya estan creadas las queys.

